### PR TITLE
Add boolean combine for Maybe

### DIFF
--- a/oslash/maybe.py
+++ b/oslash/maybe.py
@@ -47,6 +47,9 @@ class Maybe(Monad, Monoid, Applicative, Functor, metaclass=ABCMeta):
     def __repr__(self) -> str:
         return self.__str__()
 
+    def __bool__(self) -> "Maybe":
+        return bool(self.value)
+
 
 class Just(Maybe):
 

--- a/tests/test_maybe.py
+++ b/tests/test_maybe.py
@@ -308,3 +308,25 @@ class TestMaybeMonad(unittest.TestCase):
             m.bind(f).bind(g),
             m.bind(lambda x: f(x).bind(g))
         )
+
+    def test_combine_just_and_just_rule1(self):
+        self.assertEquals(
+            Just(5) and Just(6),
+            Just(6)
+        )
+
+    def test_combine_just_and_just_rule2(self):
+        self.assertEquals(
+            Just(0) and Just(6),
+            Just(0)
+        )
+    def test_combine_just_or_nothing_rule1(self):
+        self.assertEquals(
+            Just(5) or Nothing,
+            Just(5)
+        )
+    def test_combine_just_or_nothing_rule2(self):
+        self.assertEquals(
+            Just(0) or Nothing,
+            Nothing
+        )


### PR DESCRIPTION
In my opinion we need combine Maybe instance by boolean operator.
For example when I want to check a value is None and return Nothing instead of Just(None)
```
return value and Just(value) or Nothing()
```
Should be
```
return Just(value) or Nothing()
```
