### PR TITLE
PEP 479 - StopIterator is replaced with RuntimeError when raised insi…

### DIFF
--- a/oslash/list.py
+++ b/oslash/list.py
@@ -105,7 +105,7 @@ class List(Monad, Monoid, Applicative, Functor, Sized, Iterable):
         xs = self  # Don't think we can avoid this mutable local
         while True:
             if xs.null():
-                raise StopIteration
+                return
 
             yield xs.head()
             xs = xs.tail()


### PR DESCRIPTION
…de a generator therefore cannot print an empty list