### PR TITLE
Add repr to Left and Right

### DIFF
--- a/oslash/either.py
+++ b/oslash/either.py
@@ -100,6 +100,9 @@ class Right(Either[TSource, TError]):
     def __str__(self) -> str:
         return "Right %s" % self._value
 
+    def __repr__(self) -> str:
+        return f"Right({self._value!r})"
+
 
 class Left(Either[TSource, TError]):
 
@@ -130,6 +133,9 @@ class Left(Either[TSource, TError]):
 
     def __str__(self) -> str:
         return "Left: %s" % self._error
+
+    def __repr__(self) -> str:
+        return f"Left({self._error!r})"
 
 
 assert(isinstance(Either, Functor))


### PR DESCRIPTION
I've found these classes need repr's when debugging.

Before:
```python
>>> Left(1)
<oslash.either.Left object at 0x10b728d90>
```
After:
```python
>>> Left(1)
Left(1)
```