### PR TITLE
include LICENSE

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include oslash/_version.py
+include LICENSE


### PR DESCRIPTION
This will include the license file in the PyPI sdist. Context: I'm trying to get this package onto Conda Forge and they require the license file to be bundled in the source code distribution.