### PR TITLE
Fix str() bug for tuple values

### DIFF
--- a/oslash/either.py
+++ b/oslash/either.py
@@ -98,7 +98,7 @@ class Right(Either[TSource, TError]):
         return isinstance(other, Right) and self._value == other._value
 
     def __str__(self) -> str:
-        return "Right %s" % self._value
+        return f"Right {self._value}"
 
 
 class Left(Either[TSource, TError]):
@@ -129,7 +129,7 @@ class Left(Either[TSource, TError]):
         return isinstance(other, Left) and self._error == other._error
 
     def __str__(self) -> str:
-        return "Left: %s" % self._error
+        return f"Left: {self._error}"
 
 
 assert(isinstance(Either, Functor))

--- a/oslash/identity.py
+++ b/oslash/identity.py
@@ -52,7 +52,7 @@ class Identity(Generic[TSource]):
         return self._value == other()
 
     def __str__(self) -> str:
-        return "Identity(%s)" % self._value
+        return f"Identity({self._value})"
 
     def __repr__(self) -> str:
         return str(self)

--- a/oslash/maybe.py
+++ b/oslash/maybe.py
@@ -166,7 +166,7 @@ class Just(Maybe[TSource]):
         return bool(other.map(lambda other_value: other_value == self._value))
 
     def __str__(self) -> str:
-        return "Just %s" % self._value
+        return f"Just {self._value}"
 
     def __repr__(self) -> str:
         return str(self)


### PR DESCRIPTION
Replaced the use of old-style formatting strings in __str__ methods.

At first, that seems like a dated but harmless practice, but unfortunately

While dated and seemingly a harmless practice, OSlash actually uses it in an incorrect way.

If a program using OSlash deals with types other than strings, then the __str__ methods for classes like `Left`, `Right`, and `Either`, OSlash directly writes:

    return '%s' % value

where `value` is an arbitrary type.

Unfortunately, '%s' % value is only guaranteed to work if the value is a string, since Python will not call `str()` on it.

(Well, more precisely, `'%s' % value` is guaranteed to *fail* if the value happens to be a tuple of a certain kind, since Python will try to unpack the tuple into the string formatting operation)

The upshot is that such programs will get TypeErrors.  Instead, use Python 3.8+ f-strings to guarantee that the value is converted to a string.