### PR TITLE
fix https://github.com/dbrattli/OSlash/issues/35

### DIFF
--- a/oslash/typing/applicative.py
+++ b/oslash/typing/applicative.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod
 
-from typing import Callable, TypeVar, Protocol
-from typing_extensions import runtime_checkable
+from typing import Callable, TypeVar, Protocol, runtime_checkable
 
 TSource = TypeVar('TSource')
 TResult = TypeVar('TResult')

--- a/oslash/typing/functor.py
+++ b/oslash/typing/functor.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod
 
-from typing import TypeVar, Protocol, Callable
-from typing_extensions import runtime_checkable
+from typing import TypeVar, Protocol, Callable, runtime_checkable
 
 TSource = TypeVar('TSource', covariant=True)
 TResult = TypeVar('TResult')

--- a/oslash/typing/monad.py
+++ b/oslash/typing/monad.py
@@ -8,8 +8,7 @@ All instances of the Monad typeclass should obey the three monad laws:
 """
 
 from abc import abstractmethod
-from typing import TypeVar, Protocol, Callable
-from typing_extensions import runtime_checkable
+from typing import TypeVar, Protocol, Callable, runtime_checkable
 
 TSource = TypeVar('TSource')
 TResult = TypeVar('TResult')

--- a/oslash/typing/monoid.py
+++ b/oslash/typing/monoid.py
@@ -1,6 +1,5 @@
 from abc import abstractmethod
-from typing import Protocol, TypeVar
-from typing_extensions import runtime_checkable
+from typing import Protocol, TypeVar, runtime_checkable
 
 TSource = TypeVar('TSource')
 


### PR DESCRIPTION
- https://github.com/dbrattli/OSlash/issues/35
- https://github.com/python/typing_extensions/issues/372

> This happens because you're mixing typing.Protocol with typing_extensions.runtime_checkable. If you either import both symbols from typing or both symbols from typing_extensions, the error goes away.